### PR TITLE
Downgrade google-location-services to 9.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ android.libraryVariants.all { variant ->
 }
 
 dependencies {
-    compile "com.google.android.gms:play-services-location:9.8.0"
+    compile "com.google.android.gms:play-services-location:9.6.1"
     compile "com.android.volley:volley:1.0.0"
     testCompile 'junit:junit:4.12'
     testCompile('com.android.support.test:runner:0.4') {


### PR DESCRIPTION
- 9.8.0 is too recent meaning we need to prompt many devices to upgrade (friction)
- Also 9.8.0 doesn't work on the android emulators yet