### PR TITLE
Only check mdns when on wifi

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
   <application>
     <receiver android:name=".ReceiverBackgroundScanner">

--- a/src/main/java/org/mozilla/magnet/scanner/mdns/ScannerMdns.java
+++ b/src/main/java/org/mozilla/magnet/scanner/mdns/ScannerMdns.java
@@ -1,8 +1,11 @@
 package org.mozilla.magnet.scanner.mdns;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.nsd.NsdManager;
 import android.net.nsd.NsdServiceInfo;
+
 import android.util.Log;
 import android.webkit.URLUtil;
 
@@ -89,12 +92,24 @@ public class ScannerMdns extends BaseScanner implements NsdManager.DiscoveryList
         return name;
     }
 
+    private boolean isLanConnection() {
+        ConnectivityManager cm =
+                  (ConnectivityManager)mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.getType() == ConnectivityManager.TYPE_WIFI;
+    }
+
     /**
      * Starts the mDNS discovery.
      */
     @Override
     public void start(MagnetScannerListener listener) {
         if (isStarted()) return;
+        if (!isLanConnection()) {
+            return;
+        }
+
         super.start(listener);
         mNsdManager.discoverServices(MDNS_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, this);
     }


### PR DESCRIPTION
On my phone, `mdnsd` reportedly uses a relatively large amount of battery compared to other processes (about 20% of a total charge while using Magnet).  Restrict mdns discovery to only run when on a WiFi connection.


r? @wilsonpage